### PR TITLE
ci: fix arm64 windows build failure

### DIFF
--- a/triplets/x64-win-llvm/x64-win-llvm.toolchain.cmake
+++ b/triplets/x64-win-llvm/x64-win-llvm.toolchain.cmake
@@ -50,7 +50,10 @@ set(ignore_werror "/WX-")
 cmake_language(DEFER CALL add_compile_options "/WX-") # make sure the flag is added at the end!
 
 # general architecture flags
-set(arch_flags "-mcrc32")
+set(arch_flags "")
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL x64)
+  string(APPEND arch_flags "-mcrc32")
+endif()
 # -mcrc32 for libpq
 # -mrtm for tbb (will break qtdeclarative since it cannot run the executables in CI)
 # -msse4.2 for everything which normally cl can use. (Otherwise strict sse2 only.)


### PR DESCRIPTION
Windows arm build failed due to -mcrc32 option not available on `arm64-pc-windows-msvc` target. So disabled it on arm64 target.
```
    FAILED: CMakeFiles/cmTC_d1b64.dir/testCCompiler.c.obj 
    C:\PROGRA~1\LLVM\bin\clang-cl.exe  /nologo   /nologo /DWIN32 /D_WIN64 /D_WIN32_WINNT=0x0A00 /DWINVER=0x0A00 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D_ATL_SECURE_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS /D_CRT_INTERNAL_NONSTDC_NAMES /D_CRT_DECLARE_NONSTDC_NAMES /D_FORCENAMELESSUNION -mcrc32 --target=arm64-pc-windows-msvc /utf-8 -std:c11 -D__STDC__=1 -Wno-implicit-function-declaration /WX-   /O2 /Oi  /MT  /Z7 /Brepro /DNDEBUG /std:c11 -MT /showIncludes /FoCMakeFiles\cmTC_d1b64.dir\testCCompiler.c.obj /FdCMakeFiles\cmTC_d1b64.dir\ -c -- C:\vcpkg\buildtrees\ffmpeg\arm64-win-llvm-static-release-rel\CMakeFiles\CMakeScratch\TryCompile-qaxupm\testCCompiler.c
    clang-cl: error: unsupported option '-mcrc32' for target 'arm64-pc-windows-msvc'
    ninja: build stopped: subcommand failed.

```

CI: https://github.com/KhoraLee/ffmpeg-core/actions/runs/10715450447