### PR TITLE
Bump to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
 
   create-release:
     needs: [build]
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     if: github.ref == 'refs/heads/master'
     permissions:
       contents: write


### PR DESCRIPTION
create-release fails with:
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11