### PR TITLE
Enable HEVC parser temporarily to fix link error

### DIFF
--- a/ffmpeg.patch
+++ b/ffmpeg.patch
@@ -17,7 +17,7 @@ index 519b343af0..7740bd7c5a 100644
 +string(APPEND OPTIONS " --enable-encoder=ffv1 --enable-encoder=mpeg4 --enable-encoder=mjpeg")
 +string(APPEND OPTIONS " --enable-muxer=avi")
 +string(APPEND OPTIONS " --enable-demuxer=h264 --enable-demuxer=m4v --enable-demuxer=mp3 --enable-demuxer=mpegvideo --enable-demuxer=mpegps --enable-demuxer=mjpeg --enable-demuxer=mov --enable-demuxer=avi --enable-demuxer=aac --enable-demuxer=pmp --enable-demuxer=oma --enable-demuxer=pcm_s16le --enable-demuxer=pcm_s8 --enable-demuxer=wav")
-+string(APPEND OPTIONS " --enable-parser=h264 --enable-parser=mpeg4video --enable-parser=mpegaudio --enable-parser=mpegvideo --enable-parser=mjpeg --enable-parser=aac --enable-parser=aac_latm")
++string(APPEND OPTIONS " --enable-parser=h264 --enable-parser=hevc --enable-parser=mpeg4video --enable-parser=mpegaudio --enable-parser=mpegvideo --enable-parser=mjpeg --enable-parser=aac --enable-parser=aac_latm")
 +string(APPEND OPTIONS " --enable-protocol=file")
 +string(APPEND OPTIONS " --enable-bsf=mjpeg2jpeg")
 +string(APPEND OPTIONS " --enable-indev=dshow")


### PR DESCRIPTION
There's a ffmpeg bug when enabling only h264 that makes linking fail with an undefined reference to `ff_aom_uninit_film_grain_params`: https://lists.ffmpeg.org/pipermail/ffmpeg-devel/2025-May/343410.html
A fix is already upstream, but a new stable version (7.1.2) containing the fix has not been released yet.
For now, let's select the HEVC parser which also makes the `aom_film_grain.o` object file to be included, which fixes the undefined reference error (I'll revert this change after ffmpeg 7.1.2 has been released and vcpkg updated).

Reference: https://github.com/Vita3K/Vita3K/pull/3621#issuecomment-2972212115