### PR TITLE
Bump to ffmpeg 7.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           (cd ${{ matrix.vcpkg-root }} && git fetch origin)
           (cd ${{ matrix.vcpkg-root }} && git reset --hard)
-          (cd ${{ matrix.vcpkg-root }} && git checkout 41f90cc7b84116517b01f729af17fc735e9cd821)
+          (cd ${{ matrix.vcpkg-root }} && git checkout 34823ada10080ddca99b60e85f80f55e18a44eea)
           (cd ${{ matrix.vcpkg-root }} && git apply --ignore-space-change --ignore-whitespace --3way ${{ github.workspace }}/ffmpeg.patch)
 
       - name: Build ffmpeg


### PR DESCRIPTION
vcpkg bump to ffmpeg 7.1.2 was done in https://github.com/microsoft/vcpkg/pull/47384.

Closes https://github.com/Vita3K/ffmpeg-core/pull/21.